### PR TITLE
remove multiple uib-configurable subscribers

### DIFF
--- a/projects/lib/src/configurable/configurable.directive.ts
+++ b/projects/lib/src/configurable/configurable.directive.ts
@@ -8,7 +8,6 @@ import {
   Renderer2,
   TemplateRef,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
 
 import { Configurable, ConfigurableService } from './configurable.service';
 
@@ -21,24 +20,14 @@ export class ConfigurableDirective implements OnDestroy, Configurable {
   @Input() enableContainers?: boolean;
   @Input() templates?: Record<string, TemplateRef<any>>;
 
-  sub: Subscription;
-
   constructor(
     private configurableService: ConfigurableService,
     private el: ElementRef,
     private renderer: Renderer2
   ) {
-    this.sub = this.configurableService.edited$.subscribe((configurable) => {
-      if (configurable.id === this.id) {
-        this.renderer.addClass(this.el.nativeElement, 'edited');
-      } else {
-        this.renderer.removeClass(this.el.nativeElement, 'edited');
-      }
-    });
   }
 
   ngOnDestroy() {
-    this.sub.unsubscribe();
   }
 
   @HostBinding('class')
@@ -64,7 +53,22 @@ export class ConfigurableDirective implements OnDestroy, Configurable {
   @HostListener('click', ['$event'])
   click(event: MouseEvent) {
     event.stopPropagation();
+    
+    // before to set 'edited' class to current element
+    // send it to configurableService to update the previous element and call it's removeEdited() method
     this.configurableService.clickConfigurable(this);
+    
+    // now, previous 'edited' class should be correct,
+    // we can safely set the 'edited' class to the current element
+    if (this.el.nativeElement.classList.contains('edited')) {
+      this.removeEdited();
+    } else {
+      this.renderer.addClass(this.el.nativeElement, 'edited');
+    }
+  }
+  
+  removeEdited() {
+    this.renderer.removeClass(this.el.nativeElement, 'edited');
   }
 
   highlight() {

--- a/projects/lib/src/configurable/configurable.service.ts
+++ b/projects/lib/src/configurable/configurable.service.ts
@@ -6,6 +6,7 @@ export interface Configurable {
   zone: string;
   enableContainers?: boolean;
   templates?: Record<string, TemplateRef<any>>;
+  removeEdited: () => void;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -14,6 +15,9 @@ export class ConfigurableService {
 
   // currently edited element'id
   edited$ = new Subject<Configurable>();
+  
+  // previous edited element
+  previousConfigurableElement?: Configurable;
 
   get hoveredId(): string | undefined {
     return this._hoveredId;
@@ -36,6 +40,18 @@ export class ConfigurableService {
   }
 
   clickConfigurable(configurable: Configurable) {
+    if (!this.previousConfigurableElement) {
+      // previous is undefined
+      this.previousConfigurableElement = configurable;
+    } else if (this.previousConfigurableElement.id !== configurable.id || (this.previousConfigurableElement.id === configurable.id && this.previousConfigurableElement.zone !== configurable.zone)) {
+      // previous exist and it's id don't match with the new configurable element
+      this.previousConfigurableElement.removeEdited();
+      this.previousConfigurableElement = configurable;
+    }else if (this.previousConfigurableElement.id === configurable.id && this.previousConfigurableElement.zone === configurable.zone) {
+      // same id and same zone
+      this.previousConfigurableElement = undefined;
+    }
+    
     this.edited$.next(configurable);
   }
 }


### PR DESCRIPTION
Each time an item enters 'edit' mode, all uib-configurable items are notified (if hundreds of items exist, hundreds of notifications must be resolved), just to set on/off their "edited" class. This can cause weird results as element could be shared within mulitple containers.

With this PR, only the 2 elements involved are impacted.
The edited one, puts his "edited" class and the previous remove it.

No more useless notifications.