### PR TITLE
(configurator) add debounce

### DIFF
--- a/projects/lib/src/configurator/editors/class-editor.component.ts
+++ b/projects/lib/src/configurator/editors/class-editor.component.ts
@@ -9,7 +9,7 @@ import { ConfiguratorContext } from '../configurator.models';
     type="text"
     name="classes"
     [(ngModel)]="context.config.classes"
-    (ngModelChange)="context.configChanged()"
+    (ngModelChangeDebounced)="context.configChanged()"
   />
   `,
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/projects/lib/src/utils/model-change.directive.ts
+++ b/projects/lib/src/utils/model-change.directive.ts
@@ -1,0 +1,29 @@
+import { AfterContentInit, Directive, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { NgModel } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
+@Directive({ selector: '[ngModelChangeDebounced]' })
+export class NgModelChangeDebouncedDirective implements OnDestroy, AfterContentInit {
+  @Input() ngModelDebounceTime = 1000;
+  @Output() ngModelChangeDebounced = new EventEmitter<any>()
+  
+  private subs: Subscription;
+
+  constructor(private ngModel: NgModel) {}
+  
+  ngAfterContentInit(): void {
+    this.subs = this.ngModel.update
+    .pipe(
+      distinctUntilChanged(),
+      debounceTime(this.ngModelDebounceTime),
+    )
+    .subscribe((value) => {
+      this.ngModelChangeDebounced.emit(value);
+    });
+  }
+  
+  ngOnDestroy(): void {
+    this.subs.unsubscribe();
+  }
+}

--- a/projects/lib/src/utils/public-api.ts
+++ b/projects/lib/src/utils/public-api.ts
@@ -2,3 +2,4 @@ export * from './template-name.directive';
 export * from './modal.component';
 export * from './tooltip.directive';
 export * from './utils.module';
+export * from './model-change.directive';

--- a/projects/lib/src/utils/utils.module.ts
+++ b/projects/lib/src/utils/utils.module.ts
@@ -3,10 +3,21 @@ import { NgModule } from '@angular/core';
 import { TooltipDirective } from './tooltip.directive';
 import { ModalComponent } from './modal.component';
 import { TemplateNameDirective } from './template-name.directive';
+import { NgModelChangeDebouncedDirective } from './model-change.directive';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [TemplateNameDirective, ModalComponent, TooltipDirective],
-  exports: [TemplateNameDirective, ModalComponent, TooltipDirective],
+  declarations: [
+    ModalComponent,
+    TemplateNameDirective,
+    TooltipDirective,
+    NgModelChangeDebouncedDirective,
+  ],
+  exports: [
+    ModalComponent,
+    TemplateNameDirective,
+    TooltipDirective,
+    NgModelChangeDebouncedDirective,
+  ],
 })
 export class UtilsModule {}


### PR DESCRIPTION
* new ngModelChangeDebounced directive

This directive add debounce on `ngModelChange` event. Instead of use `ngModelChange` output, use `ngModelChangeDebounced` output to add debounce automatically.

```html
<input type"text" [(ngModel)]="model" (ngModelChangeDebounced)="changeHandler()" />
```

To specify debounce time, just add `ngModelChangedDebouncedTime` attribute. By default, debounce time is 1 000ms

```html
<input type"text" [(ngModel)]="model" (ngModelChangeDebounced)="changeHandler()"  ngModelChangeDebouncedTime="300" />
```