### PR TITLE
(tooltip) remove body as container by default

### DIFF
--- a/projects/lib/src/configurator/editors/flex-editor.component.ts
+++ b/projects/lib/src/configurator/editors/flex-editor.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { ComponentConfig, ConfigService } from '../../configuration';
+import { TooltipPlacement } from '../../utils';
 
 declare interface FlexOption {
   key: string;
@@ -17,7 +18,7 @@ export class FlexEditorComponent implements OnChanges {
   @Input() config: ComponentConfig;
   
   // tooltip's placement
-  placement = "bottom";
+  placement: TooltipPlacement = "bottom";
   
   classes: string[];
 

--- a/projects/lib/src/utils/tooltip.directive.ts
+++ b/projects/lib/src/utils/tooltip.directive.ts
@@ -1,10 +1,12 @@
-import { AfterContentInit, Directive, ElementRef, HostBinding, Input, OnChanges, OnDestroy } from "@angular/core";
+import { Directive, ElementRef, Input, OnChanges, OnDestroy } from "@angular/core";
 import { Tooltip } from "bootstrap";
+
+export type TooltipPlacement = 'auto' | 'top' | 'bottom' | 'left' | 'right';
 
 @Directive({
   selector: '[uib-tooltip]'
 })
-export class TooltipDirective implements OnChanges, OnDestroy, AfterContentInit {
+export class TooltipDirective implements OnChanges, OnDestroy {
   @Input('uib-tooltip') html: string;
   
   /**
@@ -17,14 +19,14 @@ export class TooltipDirective implements OnChanges, OnDestroy, AfterContentInit 
   @Input() config?: Partial<Omit<Tooltip.Options, 'title' | 'placement' | 'container'>> = {
     html: true,
     sanitize: false,
-    delay: 300,
+    delay: { show: 300, hide: 0 },
     trigger: 'hover'
   };
   
   /**
    * How to position the tooltip.
    */
-  @Input() placement: 'auto' | 'top' | 'bottom' | 'left' | 'right' = 'auto';
+  @Input() placement: TooltipPlacement = "auto";
   
   /**
    * Append the tooltip to a specific element.
@@ -32,43 +34,25 @@ export class TooltipDirective implements OnChanges, OnDestroy, AfterContentInit 
    * By default, tooltip is append to `uib-toolbar` component.
    * When `undefined`, tooltip is append to his host element.
    */
-  @Input() container?: string | Element = "uib-toolbar";
+  @Input() container?: string | Element;
 
   tooltip?: Tooltip;
-    
-  // @Input() it's used to trigger the changes detection cycle for the directive
-  @HostBinding('disabled')
-  @Input() disabled: boolean;
 
   constructor(public el: ElementRef){}
 
   ngOnChanges() {
-    // when element is disabled, remove tooltip otherwise it will be shown/created when enabled
-    this.tooltip?.dispose();
-    this.setTooltip();
-  }
-  
-  ngAfterContentInit(): void {
-    this.setTooltip();
-  }
-
-  ngOnDestroy() {
-    this.tooltip?.dispose();
-  }
-  
-  /**
-   * * If the `html` property is set, create a tooltip with the `Tooltip.getOrCreateInstance` method
-   */
-  setTooltip() {
-    if (this.html) {
-      // tooltip trigger by default is now 'hover' instead of 'hover focus'
-      // this, prevents tooltip display on component focused
+    this.tooltip?.dispose(); // Force the creation of a new tooltip, or else the content is not updated
+    if(this.html) {
       this.tooltip = Tooltip.getOrCreateInstance(this.el.nativeElement, {
         ...this.config,
         placement: this.placement,
         title: this.html,
-        container: this.container || this.el.nativeElement,
+        container: this.container || this.el.nativeElement
       });
     }
+  }
+
+  ngOnDestroy() {
+    this.tooltip?.dispose();
   }
 }


### PR DESCRIPTION
* `body` is not anymore the tooltip's container by default.
*  by default, the host element is the tooltip container.