### PR TITLE
(fix) missing $implicit keyword in zone component

### DIFF
--- a/projects/lib/src/dynamic-views/zone/zone.component.html
+++ b/projects/lib/src/dynamic-views/zone/zone.component.html
@@ -1,5 +1,5 @@
 <ng-container
-*ngTemplateOutlet="isArray ? array : zone; context: { data, first: 'true' }"
+*ngTemplateOutlet="isArray ? array : zone; context: { $implicit: data, first: 'true' }"
 ></ng-container>
 
 <!-- data is an array -->


### PR DESCRIPTION
Without this keyword, `let-data` is undefined here:

```html
<!-- data is an array -->
<ng-template #array let-data>
  <ng-container *ngFor="let d of data; let index = index; let first = first"
    [ngTemplateOutlet]="zone"
    [ngTemplateOutletContext]="{ index, first }">
  </ng-container>
</ng-template>
```