### PR TITLE
(fix) issues relative to refactoring

### DIFF
--- a/projects/lib/src/configurator/configurator.component.html
+++ b/projects/lib/src/configurator/configurator.component.html
@@ -21,7 +21,7 @@
 
     <ng-container *ngIf="!_showTree && obs.edited as edited">
       <!-- CONFIGURATOR -->
-      <div class="text-muted" *ngIf="edited.context.templates?.[edited.config.type]?.title as description">
+      <div class="text-muted" *ngIf="edited.context.templates?.[edited.config.type]?.description as description">
         {{description}}
         <hr />
       </div>
@@ -53,9 +53,9 @@
       </uib-html-editor>
 
       <!-- Separator to mark the difference between the type-specific configurator and the generic configuration options -->
-      <ng-container *ngIf="configurators[edited.config.type]?.templateRef || edited.config.type.startsWith('_')">
-        <hr />
-      </ng-container>
+      <!-- <ng-container > -->
+      <hr *ngIf="configurators[edited.config.type]?.templateRef || edited.config.type.startsWith('_')" />
+      <!-- </ng-container> -->
 
       <div class="mb-3" *ngIf="edited.options.showCssClasses">
         <uib-class-editor [context]="edited"></uib-class-editor>
@@ -65,27 +65,26 @@
         <uib-bs-spacing-editor [config]="edited.config"></uib-bs-spacing-editor>
       </div>
 
-      <details [attr.open]="edited.config.condition? '' : undefined"
-        class="mb-3"
-        *ngIf="edited.options.showConditionalDisplay && (edited.context.data || edited.context.conditionsData)"
-      >
+      <details *ngIf="edited.options.showConditionalDisplay && (edited.context.data || edited.context.conditionsData)"
+        [attr.open]="edited.config.condition? '' : undefined"
+        class="mb-3">
         <summary uib-tooltip="Display this component only if the data validates a rule" i18n-uib-tooltip i18n>Conditional display</summary>
         <uib-condition-editor [context]="edited"></uib-condition-editor>
       </details>
 
       <div class="d-flex justify-content-start mb-1">
-        <button class="btn btn-outline-danger me-2"
+        <button *ngIf="edited.options.showRemove && edited.context.parentId"
+          class="btn btn-outline-danger me-2"
           (click)="remove(edited.context)"
           uib-tooltip="Remove this component from its parent"
-          *ngIf="edited.options.showRemove && edited.context.parentId"
           i18n-uib-tooltip i18n
         >
           Remove
         </button>
-        <button class="btn btn-outline-secondary"
+        <button *ngIf="edited.options.showDuplicate"
+          class="btn btn-outline-secondary"
           (click)="duplicate(edited.context)"
           uib-tooltip="Duplicate this component within its parent"
-          *ngIf="edited.options.showDuplicate"
           i18n-uib-tooltip i18n
         >
           Duplicate

--- a/projects/lib/src/configurator/palette/palette.component.html
+++ b/projects/lib/src/configurator/palette/palette.component.html
@@ -58,5 +58,5 @@
 
 <!-- Modal -->
 <uib-modal [title]="modal?.title" [show]="!!modal" (close)="onModalClose($event)">
-  <div *ngTemplateOutlet="modal?.configurator.template; context: { $implicit: modal }"></div>
+  <div *ngTemplateOutlet="modal?.configurator.templateRef; context: { $implicit: modal }"></div>
 </uib-modal>

--- a/projects/lib/src/configurator/palette/palette.component.ts
+++ b/projects/lib/src/configurator/palette/palette.component.ts
@@ -103,7 +103,7 @@ export class PaletteComponent implements OnInit, OnChanges, OnDestroy {
           type,
           display: template.display || type,
           iconClass: template.iconClass,
-          title: template.title,
+          title: template.description,
           createConfig: (id: string) => this.openModal(id, type, this.configurators[type]),
         });
       });

--- a/projects/lib/src/dynamic-views/item/item.component.html
+++ b/projects/lib/src/dynamic-views/item/item.component.html
@@ -6,7 +6,7 @@
 <ng-container
   *ngIf="!config.type.startsWith('_') && condition"
   [ngTemplateOutlet]="zoneRef.templates[config.type || id]?.templateRef"
-  [ngTemplateOutletContext]="{ $implicit: config, data: _data, id: id }"
+  [ngTemplateOutletContext]="{ $implicit: config, data: _data, id }"
 ></ng-container>
 
 <ng-container *ngIf="config.type === '_container' && condition && !configurable">

--- a/projects/lib/src/utils/directive/template-name.directive.ts
+++ b/projects/lib/src/utils/directive/template-name.directive.ts
@@ -13,15 +13,15 @@ export class TemplateNameDirective {
   /**
    * name used by the configurator to identify the component
    */
-  @Input() display?: string;
+  @Input('uib-templateDisplay') display?: string;
   /**
    * icon used by the configurator to identify the component
    */
-  @Input() iconClass?: string;
+  @Input('uib-templateIconClass') iconClass?: string;
   /**
-   * title used by the configurator
+   * description used by the configurator
    */
-  @Input() title?: string;
+  @Input('uib-templateDescription') description?: string;
 
   templateRef: TemplateRef<any>;
 


### PR DESCRIPTION
### template-name.directive.ts
* rename `title` to `description` to avoid confusion with the `title` attribute used for tooltip.

### modal
* use `templateRef` instead of `template` (refacto issue)
