### PR TITLE
(feat) add uib-module as an imports helper

### DIFF
--- a/projects/lib/src/public-api.ts
+++ b/projects/lib/src/public-api.ts
@@ -14,3 +14,5 @@ export * from './utils';
 
 export * from './svg/svg-icons';
 export * from "./utils/svg-icon";
+
+export * from "./uib.module";

--- a/projects/lib/src/uib.module.ts
+++ b/projects/lib/src/uib.module.ts
@@ -1,0 +1,31 @@
+import { NgModule } from "@angular/core";
+
+import { AutocompleteComponent, CheckboxComponent, ColorPickerComponent, ConditionPipe, ConfigModule, ConfiguratorComponent, ImageSelectorComponent, ItemComponent, MultiSelectComponent, NgModelChangeDebouncedDirective, PaletteComponent, TemplateNameDirective, ToastComponent, ToolbarComponent, TooltipDirective, ZoneComponent } from "./public-api";
+
+
+const components = [
+  ConfigModule,
+  // standalone components
+  ConditionPipe,
+  ConfiguratorComponent,
+  ZoneComponent,
+  ItemComponent,
+  ToolbarComponent,
+  ToastComponent,
+  AutocompleteComponent,
+  CheckboxComponent,
+  ImageSelectorComponent,
+  ColorPickerComponent,
+  MultiSelectComponent,
+  PaletteComponent,
+  // directives
+  TemplateNameDirective,
+  TooltipDirective,
+  NgModelChangeDebouncedDirective,
+]
+
+@NgModule({
+  imports: [...components],
+  exports: [...components]
+})
+export class uibModule {}


### PR DESCRIPTION
* standalone components can be easily imported as a single module.