### PR TITLE
(image-selector) allow image redimension

### DIFF
--- a/projects/lib/src/configurator/image-selector/img-selector.component.ts
+++ b/projects/lib/src/configurator/image-selector/img-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 
 import { ConfiguratorContext } from "../configurator.models";
@@ -17,25 +17,70 @@ import { CommonModule } from "@angular/common";
     id="img-{{param}}"
     autocomplete="off"
     spellcheck="off"
-    [(ngModel)]="context.config[param]"
+    [(ngModel)]="context.config?.images[param].filename"
     (ngModelChangeDebounced)="onChange($event)">
   <input type="file" class="form-control-file" accept="image/png, image/jpeg, image/gif" (change)="onImageLoaded($event)">
 
-  <details *ngIf="context.config[param]">
+  <div class="d-flex flex-column mt-3" *ngIf="sizeable">
+    <div class="input-group input-group-sm">
+      <span class="input-group-text">Width</span>
+      <input type="text"
+        class="form-control"
+        [(ngModel)]="context.config?.images[param].width"
+        (ngModelChangeDebounced)="onImageDimensionChange($event, 'width')"
+        aria-label="width">
+      <span class="input-group-text">px</span>
+    </div>
+    <input type="range" id="img-{{param}}-width" name="img-{{param}}-width"
+      class="form-range mb-3"
+      min="0"
+      max="1024"
+      [(ngModel)]="context.config?.images[param].width"
+      (ngModelChangeDebounced)="context.configChanged()">
+
+    <div class="input-group input-group-sm">
+      <span class="input-group-text">Height</span>
+      <input type="text"
+        class="form-control"
+        [(ngModel)]="context.config?.images[param].height"
+        (ngModelChangeDebounced)="onImageDimensionChange($event, 'height')"
+        aria-label="height">
+      <span class="input-group-text">px</span>
+    </div>
+    <input type="range" id="img-{{param}}-height" name="img-{{param}}-height"
+      class="form-range mb-3"
+      min="0"
+      max="1024"
+      [(ngModel)]="context.config?.images[param].height"
+      (ngModelChangeDebounced)="context.configChanged()">
+  </div>
+
+  <details *ngIf="context.config?.images[param]">
     <summary>
       Preview
     </summary>
     <div>
-      <img class="mw-100 border rounded" [src]="context.config[param]">
+      <img class="mw-100 border rounded" [src]="context.config?.images[param].filename">
     </div>
   </details>
 </div>
     `
 })
-export class ImageSelectorComponent {
+export class ImageSelectorComponent implements OnChanges {
   @Input() context: ConfiguratorContext;
   @Input() param: string;
   @Input() description: string;
+  @Input() sizeable: boolean = true;
+
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // TODO: to remove with the next release
+    // convert old format to the new one
+    if (!this.context.config.images || !this.context.config.images[this.param]) {
+      this.context.config.images = {...this.context.config.images, [this.param]: { filename: this.context.config[this.param]}}
+      delete this.context.config[this.param];
+    }
+  }
 
   onImageLoaded(event: Event) {
     const file = (event.target as HTMLInputElement).files?.[0];
@@ -43,12 +88,19 @@ export class ImageSelectorComponent {
       const reader = new FileReader();
       reader.onload = () => {
         if (reader.result) {
-          this.context.config[this.param] = reader.result;
+          this.context.config.images[this.param].filename = reader.result;
           this.context.configChanged();
         }
       }
       reader.readAsDataURL(file);
     }
+  }
+
+  onImageDimensionChange(value: string, size: 'width' | 'height') {
+    if (value.trim().length === 0) {
+      this.context.config.images[this.param][size] = undefined;
+    }
+    this.context.configChanged();
   }
 
   onChange(value: string) {


### PR DESCRIPTION
This PR contains 2 specifics updates:
* image selector configurator
* config rule

### Image Selector

#### New Inputs
* sizeable: boolean = true (default)
When `true`, sizeable components allow us to modify the width and the height of each images

#### Configuration expected
```
  {
    id: string,
    type: string,
    images: {
      [key: string]: { filename: string, width?: number, height?: number },
      ...
    }
  }
```
#### Usage
```html
<uib-image-selector [sizeable]="<boolean>" [context]="<object>" param="<string>" description="<string>" />
```
E.g:
```html
<uib-image-selector [context]="context" param="logoLight" description="Logo" class="d-block mb-3" />
```
context is a specific object containing the component configuration:
```
context: {
   config:   {
    id: 'home-logo',
    type: 'home-logo',
    images: {
      logoLight: { filename: 'assets/vanilla-logo.png' },
      logoDark: { filename: 'assets/vanilla-logo-dark.png' }
    }
  }
}
```

### Updating config rule
To save the whole configuration json file in a single variable declaration.